### PR TITLE
Add 'cron'able cluster health script

### DIFF
--- a/cluster_health_emailer.sh
+++ b/cluster_health_emailer.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+$MAIL_ADDRESS=somebody@somewhere.com
+for status in $(oc get nodes -o jsonpath='{.items[*].status.conditions[?(@.reason=="KubeletReady")].status}');
+do
+  if [ "$status" != "True" ]; then
+    echo "$(oc get nodes)" | mail -s "Openshift Cluster Unstable" $MAIL_ADDRESS
+    break
+  fi
+done


### PR DESCRIPTION
a quick script to check if any nodes in the cluster are not reporting a condition of KubeletReady = True and send an email with the output of 'oc get nodes' if this is the case.  easy to put into a cron job.